### PR TITLE
Scroll to selected thumbnail item in thumbnail drawer

### DIFF
--- a/src/components/OpenSeadragonViewer/OpenSeadragonViewer.md
+++ b/src/components/OpenSeadragonViewer/OpenSeadragonViewer.md
@@ -30,11 +30,11 @@ import { scrapbook } from "../../manifests/jimmy-johnson-scrapbook";
 import { horse } from "../../manifests/horse";
 
 /**
- * Try commenting out the "manifest" prop, and testing your own "manifestUrl" value
- * below to watch it update in real time
+ * Try editing/removing/changing the "manifest" and "manifestUrl" props,
+ * test your own "manifestUrl" value and more to see how this will render images
  */
 <OpenSeadragonViewer
-  manifest={horse}
+  manifest={scrapbook}
   manifestUrl="https://iiif.stack.rdc.library.northwestern.edu/public/06/20/ea/ca/-5/4e/6-/41/81/-a/85/8-/39/dd/ea/0b/b1/c5-manifest.json"
   options={{
     showDropdown: true,
@@ -42,7 +42,7 @@ import { horse } from "../../manifests/horse";
     showToolbar: true,
     deepLinking: false,
     height: 800,
-    containerId: "myContainerId"
+    containerId: "myContainerId",
   }}
   openSeadragonOptions={{
     gestureSettingsMouse: {

--- a/src/components/Thumbnails/Thumbnails.js
+++ b/src/components/Thumbnails/Thumbnails.js
@@ -50,44 +50,46 @@ const panelListingThumbs = css`
   }
 `;
 
-export default function Thumbnails({
-  currentTileSource,
-  tileSources = [],
-  onThumbClick,
-  isPreview = false,
-}) {
-  return (
-    <div
-      data-testid="open-seadragon-thumbnails-container"
-      className="osrv-thumbnails-wrapper"
-      css={bottomPanel("relative")}
-    >
-      <div css={thumbnailView}>
-        <ul css={panelListingThumbs}>
-          {tileSources.map((t) => (
-            <li
-              key={t.id}
-              data-testid="tile-source-thumbnail"
-              onClick={() => onThumbClick(t.id)}
-              aria-label="Thumbnail"
-              className={
-                currentTileSource && currentTileSource.id === t.id
-                  ? "active"
-                  : ""
-              }
-            >
-              <img
-                src={`${t.id}/square/70,70/0/default.jpg`}
-                data-testid="thumbnail-image"
-                alt={t.label}
-              />
-            </li>
-          ))}
-        </ul>
+const Thumbnails = React.forwardRef(
+  ({ currentTileSource, tileSources = [], onThumbClick }, scrollRef) => {
+    function getClassName(t) {
+      let className = `osrv-thumbnail`;
+      if (currentTileSource && currentTileSource.id === t.id) {
+        className += ` active`;
+      }
+      return className;
+    }
+
+    return (
+      <div
+        data-testid="open-seadragon-thumbnails-container"
+        className="osrv-thumbnails-wrapper"
+        css={bottomPanel("relative")}
+      >
+        <div css={thumbnailView} ref={scrollRef}>
+          <ul css={panelListingThumbs}>
+            {tileSources.map((t) => (
+              <li
+                key={t.id}
+                data-id={t.id}
+                data-testid="tile-source-thumbnail"
+                onClick={() => onThumbClick(t.id)}
+                aria-label="Thumbnail"
+                className={getClassName(t)}
+              >
+                <img
+                  src={`${t.id}/square/70,70/0/default.jpg`}
+                  data-testid="thumbnail-image"
+                  alt={t.label}
+                />
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
+);
 
 Thumbnails.propTypes = {
   /** Current tile source displayed in OpenSeadragon viewer */
@@ -96,6 +98,6 @@ Thumbnails.propTypes = {
   onThumbClick: PropTypes.func,
   /** All tilesources for the image resource */
   tileSources: PropTypes.array,
-  /** Boolean to check if this component is called from styleguidist preview mode */
-  isPreview: PropTypes.bool,
 };
+
+export default Thumbnails;

--- a/src/components/Viewer/Viewer.js
+++ b/src/components/Viewer/Viewer.js
@@ -66,6 +66,7 @@ const Viewer = ({ manifest }) => {
   const [currentURLParams, setCurrentURLParams] = useState(
     window.location.hash
   );
+  const scrollElRef = React.useRef();
   const configProps = useContext(ConfigContext);
 
   const openSeadragonContainer = css`
@@ -192,7 +193,9 @@ const Viewer = ({ manifest }) => {
   };
 
   const handlePageChange = ({ page }) => {
-    setCurrentTileSource(canvasImageResources[page]);
+    const activeTile = canvasImageResources[page];
+    setCurrentTileSource(activeTile);
+    centerActiveThumbnail(activeTile.id);
 
     if (configProps.deepLinking) {
       updateUrl({ tileSourceIndex: page });
@@ -207,9 +210,19 @@ const Viewer = ({ manifest }) => {
     const index = canvasImageResources.findIndex(
       (element) => element.id === id
     );
-
     setCurrentTileSource(canvasImageResources[index]);
     openSeadragonInstance.goToPage(index);
+  }
+
+  /**
+   * Center selected thumbnail in the thumbnail drawer
+   * @param {String} id
+   */
+  function centerActiveThumbnail(id) {
+    const el = document.querySelector(`[data-id="${id}"]`);
+    const leftPos =
+      el.offsetLeft - scrollElRef.current.offsetWidth / 2 + el.offsetWidth / 2;
+    scrollElRef.current.scrollTo({ left: leftPos, behavior: "smooth" });
   }
 
   function initOpenSeadragon() {
@@ -315,6 +328,7 @@ const Viewer = ({ manifest }) => {
           <Thumbnails
             currentTileSource={currentTileSource}
             onThumbClick={handleThumbClick}
+            ref={scrollElRef}
             tileSources={canvasImageResources}
           />
         </div>

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -27,6 +27,7 @@ module.exports = {
         },
       ],
     },
+    devtool: "eval-source-map",
   },
   usageMode: "expand",
 };


### PR DESCRIPTION
When the viewer is displaying a canvas with multiple images, now the thumbnail drawer will scroll to the selected thumbnail, and be centered (where possible given number of thumbnail images).

The boxed navigation controls below will all trigger the centering of thumbnails

![image](https://user-images.githubusercontent.com/3020266/146420524-4dd79797-94e2-4c5a-b46b-7ea1be317724.png)
